### PR TITLE
Release 1.7.1 - Let flask figure out if the body is JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.1 (2022-04-27)
+
+* Properly interpret the content type/mimedata of POST events.
+
 # 1.7.0 (2022-04-26)
 
 * The `/github` end-point now **requires** the webhook to be configured with a *secret*, which is known to JobsDone via the `JD_GH_SECRET` configuration variable.

--- a/src/jobs_done10/server/app.py
+++ b/src/jobs_done10/server/app.py
@@ -78,10 +78,10 @@ def _handle_end_point(
         return get_version_title()
 
     # Only accept json payloads.
-    content_type = request.headers.get("Content-Type")
-    if content_type != "application/json":
+    if not request.is_json:
+        app.logger.info(f"POST body not in JSON format:\n{request.mimetype}")
         return (
-            f"Only 'application/json' content accepted, got: '{content_type}'",
+            f"Only posts in JSON format accepted",
             HTTPStatus.BAD_REQUEST,
         )
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -47,7 +47,6 @@ def configure_environment_(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(name="client")
 def client_(configure_environment: None) -> FlaskClient:
-
     return app.test_client()
 
 
@@ -273,10 +272,7 @@ def test_post_invalid_content_type(client: FlaskClient, endpoint: str) -> None:
     response = client.post(
         endpoint, json="hello", headers={"content-type": "application/text"}
     )
-    assert (
-        response.data.decode("UTF-8")
-        == f"Only 'application/json' content accepted, got: 'application/text'"
-    )
+    assert response.data.decode("UTF-8") == f"Only posts in JSON format accepted"
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 


### PR DESCRIPTION
Turns out that `Content-Type` can also receive parameters, so it is not always a simple string as assumed before.

CYI @prusse-martin @cauebs 